### PR TITLE
zig 0.14.0-dev.1421+f87dd43c1 update + repeated message fix + more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache/
+.zig-cache/
 zig-out/

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const module = b.addModule("zigpb", .{
+        .root_source_file = b.path("src/root.zig"),
+    });
+
     b.installArtifact(lib);
 
     // Creates a step for unit testing. This only builds the test executable
@@ -25,6 +29,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    lib_unit_tests.root_module.addImport("zigpb", module);
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = "zigpb",
+    .version = "0.0.0",
+    .dependencies = .{},
+    .paths = .{
+        "src",
+        "build.zig",
+        "build.zig.zon",
+    },
+}

--- a/src/test.zig
+++ b/src/test.zig
@@ -123,10 +123,10 @@ fn testEncodeDecode(comptime Msg: type, comptime val: anytype) !void {
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
 
-    try pb.encode(buf.writer(), std.testing.allocator, msg);
+    try pb.encode(std.testing.allocator, buf.writer(), msg);
 
     var fbs = std.io.fixedBufferStream(buf.items);
-    const decoded = try pb.decode(Msg, fbs.reader(), arena.allocator());
+    const decoded = try pb.decode(Msg, arena.allocator(), fbs.reader());
 
     try expectEqualMessages(Msg, msg, decoded);
 }
@@ -140,11 +140,11 @@ fn testEncodeDecodeHex(comptime Msg: type, comptime val: anytype, comptime hex: 
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
 
-    try pb.encode(buf.writer(), std.testing.allocator, msg);
+    try pb.encode(std.testing.allocator, buf.writer(), msg);
     try std.testing.expectEqualSlices(u8, unhex(hex), buf.items);
 
     var fbs = std.io.fixedBufferStream(buf.items);
-    const decoded = try pb.decode(Msg, fbs.reader(), arena.allocator());
+    const decoded = try pb.decode(Msg, arena.allocator(), fbs.reader());
 
     try expectEqualMessages(Msg, msg, decoded);
 }


### PR DESCRIPTION
**Updated the implementation to zig version 0.14.0.**

- Fixed a bug when deserializing repeated message fields (previously, the decodeSingleScalar function was mistakenly used instead of decodeSingleValue when reading repeated fields, which made it impossible to deserialize sub-messages).
- Allowed default values for strings and byte arrays.
- Fixed .repeat_pack encoding (skip encoding if the list is empty).

Public API change:
- decodeMessage -> decode
- encodeMessage -> encode

Parameters in those functions were sorted in the order they appear in functions from std.
Additionally, a couple of new tests were written.